### PR TITLE
Compatibility with typst 0.12

### DIFF
--- a/src/styles.typ
+++ b/src/styles.typ
@@ -41,6 +41,8 @@
   number,
   body
 ) = block(width: 100%, breakable: true)[#{
+  set align(left)
+
   strong(thm-type) + " "
   if number != none {
     strong(number) + " "
@@ -60,6 +62,8 @@
   number,
   body
 ) = block(width: 100%, breakable: true)[#{
+  set align(left)
+
   if number != none {
     strong(number) + " "
   }
@@ -79,6 +83,8 @@
   number,
   body
 ) = block(width: 100%, breakable: true)[#{
+  set align(left)
+
   strong(thm-type) + " "
   if number != none {
     strong(number) + " "

--- a/src/util.typ
+++ b/src/util.typ
@@ -65,11 +65,11 @@
 // Utility function to display a counter
 // at the given position.
 #let display-heading-counter-at(loc, max-heading-level) = {
-  let locations = query(selector(heading).before(loc), loc)
+  let locations = query(selector(heading).before(loc))
   if locations.len() == 0 {
     [0]
   } else {
-    let numb = query(selector(heading).before(loc), loc).last().numbering
+    let numb = query(selector(heading).before(loc)).last().numbering
     if numb != none {
       let c = counter(heading).at(loc)
       if max-heading-level != none and c.len() > max-heading-level {


### PR DESCRIPTION
I made some small changes to make this package compatible with the new typst version 0.12.

A) I adjusted to the new query syntax since the original one is now deprecated and one would get warnings.
B) I added a `set align(left)` rule so that the theorem and proof boxes of the standard styles would be rendered as before 0.12.
