### PR TITLE
Resolve Deprecation introduced in typst 0.13

### DIFF
--- a/src/util.typ
+++ b/src/util.typ
@@ -53,7 +53,7 @@
       ref-styling(it)
     } else if subgroups == refd-subgroup {
       ref-styling(it)
-    } else if type(subgroups) == "array" and subgroups.contains(refd-subgroup) {
+    } else if type(subgroups) == array and subgroups.contains(refd-subgroup) {
       ref-styling(it)
     } else {
       it


### PR DESCRIPTION
Typst 0.13 deprecates the comparison of types using strings and this will be converted into an error in a future release 0.14.
I've fixed this and tested it locally. This would solve #38.