### PR TITLE
Edit style for proofs ending in math blocks

### DIFF
--- a/src/styles.typ
+++ b/src/styles.typ
@@ -93,7 +93,20 @@
   if name != none {
     emph[(#name)] + " "
   }
-  " " + body + h(1fr) + $square$
+  " " + body
+  // Special case: proof ends in a block equation
+  if "children" in body.fields() {
+    let filtered_children = body.children.filter(child => (
+      child != [ ] and child.func() != parbreak
+    ))
+    let last_elem = filtered_children.last()
+    if last_elem.func() == math.equation and last_elem.block {
+      place(bottom + right)[$square$]
+      return
+    }
+  }
+  // Generic case: proof ends in text
+  h(1fr) + $square$
 }]
 
 // Basic theorem reference style:


### PR DESCRIPTION
Proofs ending in math blocks currently have the qed placed on a separate line creating a weird looking vertical space:
<img width="1622" height="478" alt="image" src="https://github.com/user-attachments/assets/8104ad2d-9ea6-4e13-a980-42ca8d795507" />
This changes the default proof style to align the qed correctly with the math block:
<img width="1622" height="408" alt="image" src="https://github.com/user-attachments/assets/228ba0df-db4c-44e7-b6e3-23b8a6fc2343" />
